### PR TITLE
Add unit tests for UserMonthlySummaryServiceImpl & TransactionServiceImpl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,21 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>au.com.dius</groupId>
+            <artifactId>pact-jvm-provider-junit5_2.11</artifactId>
+            <version>3.5.24</version>
+        </dependency>
+        <dependency>
+            <groupId>au.com.dius</groupId>
+            <artifactId>pact-jvm-provider-junit5_2.11</artifactId>
+            <version>3.5.24</version>
+        </dependency>
+        <dependency>
+            <groupId>au.com.dius</groupId>
+            <artifactId>pact-jvm-provider-junit5_2.11</artifactId>
+            <version>3.5.24</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/example/expensetrackerspring/service/TransactionServiceImplTest.java
+++ b/src/test/java/com/example/expensetrackerspring/service/TransactionServiceImplTest.java
@@ -1,0 +1,156 @@
+package com.example.expensetrackerspring.service;
+
+import com.example.expensetrackerspring.core.RecurrenceFrequency;
+import com.example.expensetrackerspring.core.TransactionType;
+import com.example.expensetrackerspring.core.exceptions.TransactionNotFoundException;
+import com.example.expensetrackerspring.core.exceptions.UserNotFoundException;
+import com.example.expensetrackerspring.core.persistance.entity.Transaction;
+import com.example.expensetrackerspring.core.persistance.entity.User;
+import com.example.expensetrackerspring.core.persistance.repository.TransactionRepository;
+import com.example.expensetrackerspring.core.persistance.repository.UserMonthlySummaryRepository;
+import com.example.expensetrackerspring.core.persistance.repository.UserRepository;
+import com.example.expensetrackerspring.core.service.TransactionServiceImpl;
+import com.example.expensetrackerspring.core.service.UserMonthlySummaryService;
+import com.example.expensetrackerspring.rest.payload.request.GetTransactionRequest;
+import com.example.expensetrackerspring.rest.payload.request.RemoveTransactionRequest;
+import com.example.expensetrackerspring.rest.payload.request.SaveTransactionRequest;
+import com.example.expensetrackerspring.rest.payload.response.RemoveTransactionResponse;
+import com.example.expensetrackerspring.rest.payload.response.SaveTransactionResponse;
+import com.example.expensetrackerspring.rest.payload.response.TransactionResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionServiceImplTest {
+
+    @Mock
+    private TransactionRepository transactionRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserMonthlySummaryRepository userMonthlySummaryRepository;
+    @Mock
+    private UserMonthlySummaryService userMonthlySummaryService;
+    @InjectMocks
+    private TransactionServiceImpl transactionService;
+
+    private User user;
+    private SaveTransactionRequest transactionRequest;
+    private Transaction transaction;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1L);
+        user.setUsername("testUser");
+
+        transactionRequest = new SaveTransactionRequest(
+                1L, "Groceries", "Bought groceries",
+                BigDecimal.valueOf(50), "Food",
+                LocalDate.now(), LocalDate.now(),
+                RecurrenceFrequency.SINGLE, TransactionType.EXPENSE
+        );
+
+        transaction = Transaction.builder()
+                .id(1L)
+                .user(user)
+                .name("Groceries")
+                .description("Bought groceries")
+                .amount(BigDecimal.valueOf(50))
+                .category("Food")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now())
+                .transactionType(TransactionType.EXPENSE)
+                .recurrenceFrequency(RecurrenceFrequency.SINGLE)
+                .build();
+    }
+
+    @Test
+    void saveTransaction_shouldSaveSingleTransactionSuccessfully() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
+
+        SaveTransactionResponse response = transactionService.saveTransaction(transactionRequest, 1L);
+
+        assertTrue(response.successful());
+        assertEquals("Transaction saved successfully", response.message());
+        verify(transactionRepository).save(any(Transaction.class));
+    }
+
+    @Test
+    void saveTransaction_shouldThrowExceptionWhenUserNotFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(UserNotFoundException.class,
+                () -> transactionService.saveTransaction(transactionRequest, 1L));
+    }
+
+    @Test
+    void saveTransaction_shouldThrowExceptionWhenStartDateIsNull() {
+        SaveTransactionRequest invalidRequest = new SaveTransactionRequest(
+                1L, "Rent", "Monthly rent",
+                BigDecimal.valueOf(500), "Housing",
+                null, LocalDate.now(),
+                RecurrenceFrequency.SINGLE, TransactionType.EXPENSE
+        );
+
+        assertThrows(UserNotFoundException.class,
+                () -> transactionService.saveTransaction(invalidRequest, 1L));
+    }
+
+    @Test
+    void getTransaction_shouldReturnTransactionIfExists() {
+        GetTransactionRequest request = new GetTransactionRequest(1L, TransactionType.EXPENSE);
+        when(transactionRepository.findByIdAndUserId(1L, 1L)).thenReturn(Optional.of(transaction));
+
+        Optional<TransactionResponse> response = transactionService.getTransaction(request, 1L);
+
+        assertTrue(response.isPresent());
+        assertEquals("Groceries", response.get().name());
+    }
+
+    @Test
+    void getTransaction_shouldReturnEmptyIfTransactionDoesNotExist() {
+        GetTransactionRequest request = new GetTransactionRequest(1L, TransactionType.EXPENSE);
+        when(transactionRepository.findByIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+
+        Optional<TransactionResponse> response = transactionService.getTransaction(request, 1L);
+
+        assertTrue(response.isEmpty());
+    }
+
+    @Test
+    void deleteTransaction_shouldDeleteTransactionIfExists() {
+        RemoveTransactionRequest request = new RemoveTransactionRequest(1L);
+        when(transactionRepository.findByIdAndUserId(1L, 1L)).thenReturn(Optional.of(transaction));
+
+        RemoveTransactionResponse response = transactionService.deleteTransaction(request, 1L);
+
+        assertTrue(response.success());
+        assertEquals("Transaction deleted successfully", response.message());
+        verify(transactionRepository).delete(transaction);
+    }
+
+    @Test
+    void deleteTransaction_shouldThrowExceptionIfTransactionNotFound() {
+        RemoveTransactionRequest request = new RemoveTransactionRequest(1L);
+        when(transactionRepository.findByIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+
+        assertThrows(TransactionNotFoundException.class,
+                () -> transactionService.deleteTransaction(request, 1L));
+    }
+}
+

--- a/src/test/java/com/example/expensetrackerspring/service/UserMonthlySummaryServiceImplTest.java
+++ b/src/test/java/com/example/expensetrackerspring/service/UserMonthlySummaryServiceImplTest.java
@@ -1,0 +1,141 @@
+package com.example.expensetrackerspring.service;
+
+import com.example.expensetrackerspring.core.TransactionType;
+import com.example.expensetrackerspring.core.persistance.entity.Transaction;
+import com.example.expensetrackerspring.core.persistance.entity.User;
+import com.example.expensetrackerspring.core.persistance.entity.UserMonthlySummary;
+import com.example.expensetrackerspring.core.persistance.repository.TransactionRepository;
+import com.example.expensetrackerspring.core.persistance.repository.UserMonthlySummaryRepository;
+import com.example.expensetrackerspring.core.service.UserMonthlySummaryServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserMonthlySummaryServiceImplTest {
+
+    @Mock
+    private UserMonthlySummaryRepository userMonthlySummaryRepository;
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @InjectMocks
+    private UserMonthlySummaryServiceImpl userMonthlySummaryService;
+
+    private User user;
+    private UserMonthlySummary summary;
+    private Transaction transaction;
+    private LocalDate testDate;
+    private YearMonth testMonth;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1L);
+        user.setUsername("testUser");
+
+        testDate = LocalDate.of(2024, 2, 15);
+        testMonth = YearMonth.of(2024, 2);
+
+        summary = new UserMonthlySummary();
+        summary.setUser(user);
+        summary.setDate(testDate);
+        summary.setIncome(BigDecimal.ZERO);
+        summary.setExpenses(BigDecimal.ZERO);
+        summary.setSavings(BigDecimal.ZERO);
+
+        transaction = Transaction.builder()
+                .id(1L)
+                .user(user)
+                .amount(BigDecimal.valueOf(100))
+                .transactionType(TransactionType.INCOME)
+                .startDate(testDate)
+                .build();
+    }
+
+    @Test
+    void shouldUpdateDailySummary() {
+        YearMonth testMonth = YearMonth.from(testDate); // February 2024
+        LocalDate lastDayOfPreviousMonth = testMonth.minusMonths(1).atEndOfMonth(); // 2024-01-31
+        LocalDate previousDay = lastDayOfPreviousMonth.minusDays(1);   // 2024-01-30
+
+        // Stub for previous day (used in getPreviousDaySavings)
+        UserMonthlySummary previousSummary = new UserMonthlySummary();
+        previousSummary.setUser(user);
+        previousSummary.setDate(previousDay);
+        previousSummary.setSavings(BigDecimal.ZERO);
+
+        // Lenient stubbing for daily lookup: if the day equals testDate, return our summary; otherwise, return empty.
+        lenient().when(userMonthlySummaryRepository.findByUserAndDate(eq(user), any(LocalDate.class)))
+                .thenAnswer(invocation -> {
+                    LocalDate date = invocation.getArgument(1);
+                    if (date.equals(testDate)) {
+                        return Optional.of(summary);
+                    } else if (date.equals(previousDay)) {
+                        return Optional.of(previousSummary);
+                    }
+                    return Optional.empty();
+                });
+
+
+        // Stub the transaction repository for testDate.
+        when(transactionRepository.findByUserAndDate(user, testDate))
+                .thenReturn(List.of(transaction));
+
+        // Stub for monthly lookup to include our summary.
+        when(userMonthlySummaryRepository.findByUserAndDateBetween(
+                eq(user), eq(testMonth.atDay(1)), eq(testMonth.atEndOfMonth())))
+                .thenReturn(List.of(summary));
+
+        // Execute the updateDailySummary method.
+        userMonthlySummaryService.updateDailySummary(testDate, user);
+
+        // Verify that the summary for testDate got updated.
+        assertEquals(BigDecimal.valueOf(100), summary.getIncome());
+        assertEquals(BigDecimal.ZERO, summary.getExpenses());
+        verify(userMonthlySummaryRepository, atLeastOnce()).save(any(UserMonthlySummary.class));
+    }
+
+
+
+    @Test
+    void shouldGetSummaryForMonth() {
+        when(userMonthlySummaryRepository.findByUserAndDateBetween(user, testMonth.atDay(1), testMonth.atEndOfMonth()))
+                .thenReturn(List.of(summary));
+
+        List<UserMonthlySummary> summaries = userMonthlySummaryService.getSummaryForMonth(user, testMonth.toString());
+
+        assertFalse(summaries.isEmpty());
+        assertEquals(1, summaries.size());
+        verify(userMonthlySummaryRepository, times(2))
+                .findByUserAndDateBetween(user, testMonth.atDay(1), testMonth.atEndOfMonth());
+    }
+
+    @Test
+    void shouldGetSummaryForDay() {
+        when(userMonthlySummaryRepository.findByUserAndDate(user, testDate))
+                .thenReturn(Optional.of(summary));
+
+        UserMonthlySummary result = userMonthlySummaryService.getSummaryForDay(testDate, user);
+
+        assertNotNull(result);
+        assertEquals(testDate, result.getDate());
+        verify(userMonthlySummaryRepository, times(1))
+                .findByUserAndDate(user, testDate);
+    }
+}
+


### PR DESCRIPTION
** UserMonthlySummaryServiceImpl **
- Tested daily summary updates (shouldUpdateDailySummary)
- Tested fetching summaries for a specific month (shouldGetSummaryForMonth)
- Tested fetching summary for a specific day (shouldGetSummaryForDay)
- Used lenient stubbing to handle multiple date lookups
- Verified repository interactions and data updates

** TransactionServiceImpl **
- Tested saveTransaction:
  - Successfully saves a single transaction
  - Exception when user is not found
  - Exception when start date is null

- Tested getTransaction:
  - Returns transaction if found
  - Returns empty if transaction does not exist

- Tested deleteTransaction:
  - Successfully deletes transaction
  - Exception when transaction is not found